### PR TITLE
Enable configuring NMeta on app level again

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ If you're running an older version of Vapor then have a look here:
 - [Vapor 2.x](https://github.com/nodes-vapor/n-meta/tree/vapor-2)
 - [Vapor 3.x](https://github.com/nodes-vapor/n-meta/tree/vapor-3)
 
-
-
 This header can look like this `android;production;1.2.3;4.4;Samsung S7`
  - platform
  - environment
@@ -59,30 +57,24 @@ Update your `Package.swift` file.
 
 ## Getting started 🚀
 
-Register the provider in `configure.swift`:
+Configure NMeta as per your needs, for example: 
 
 ```swift
-import NMeta
+app.nMeta = .init(exceptPath: ["/admin"])
 ```
 
-```
-try services.register(NMetaProvider())
-```
-
-You can supply your own `NMetaConfig` to the provider if needed.
-
-Next, add the middleware directly to your routes:
+Next, add the middleware directly to your routes (e.g. in `routes.swift`):
 
 ```swift
-router.grouped(NMetaMiddleware()).get("hello") { req in
-    return "Hello, world!"
+app.grouped(NMetaMiddleware()).get("hello") { req in
+    "Hello, world!"
 }
 ```
 
 or add the middleware globally (e.g. in `configure.swift`) which will add it to all routes:
 
 ```swift
-middlewares.use(NMetaMiddleware.self)
+app.middlewares.use(NMetaMiddleware())
 ```
 
 ## 🏆 Credits

--- a/Sources/NMeta/NMetaError.swift
+++ b/Sources/NMeta/NMetaError.swift
@@ -5,40 +5,36 @@ public enum NMetaError: String, Error {
     case environmentMissing
     case versionMissing
     case versionIsIncorrectFormat
-    case deviceOsMissing
+    case deviceOSMissing
     case deviceMissing
     case headerMissing
     case platformUnsupported
     case environmentUnsupported
-    case headerIsEmpty
     case nMetaIsNotAttachedToRequest
     case ivalidHeaderFormat
 }
 
 extension NMetaError: AbortError {
-    public var identifier: String {
-        return rawValue
-    }
+    public var identifier: String { rawValue }
 
     public var reason: String {
         switch self {
-        case .platformMissing: return "Platform missing"
-        case .environmentMissing: return "Environment missing"
-        case .versionMissing: return "Version missing"
+        case .platformMissing: return "NMeta: Platform missing"
+        case .environmentMissing: return "NMeta: Environment missing"
+        case .versionMissing: return "NMeta: Version missing"
         case .versionIsIncorrectFormat: return """
-            Version format incorrect. Format is 1.2.3 (major.minor.patch)
+            NMeta: Version format incorrect. Format is 1.2.3 (major.minor.patch)
         """
-        case .deviceOsMissing: return "DeviceOs missing"
-        case .deviceMissing: return "Device missing"
-        case .headerMissing: return "Header missing"
-        case .platformUnsupported: return "Platform unsupported"
-        case .environmentUnsupported: return "Environment unsupported"
-        case .headerIsEmpty: return "Header is empty"
+        case .deviceOSMissing: return "NMeta: DeviceOS missing"
+        case .deviceMissing: return "NMeta: Device missing"
+        case .headerMissing: return "NMeta: Header missing"
+        case .platformUnsupported: return "NMeta: Platform unsupported"
+        case .environmentUnsupported: return "NMeta: Environment unsupported"
         case .nMetaIsNotAttachedToRequest: return """
             NMeta is not attached to request. This is most likely cause the middleware is not used
-            on the route
+            on the route.
         """
-        case .ivalidHeaderFormat: return "Invalid header format."
+        case .ivalidHeaderFormat: return "NMeta: Invalid header format. Format is platform;environment;version;deviceOS;device."
         }
     }
 
@@ -48,12 +44,11 @@ extension NMetaError: AbortError {
         case .environmentMissing: return .badRequest
         case .versionMissing: return .badRequest
         case .versionIsIncorrectFormat: return .badRequest
-        case .deviceOsMissing: return .badRequest
+        case .deviceOSMissing: return .badRequest
         case .deviceMissing: return .badRequest
         case .headerMissing: return .badRequest
         case .platformUnsupported: return .badRequest
         case .environmentUnsupported: return .badRequest
-        case .headerIsEmpty: return .badRequest
         case .nMetaIsNotAttachedToRequest: return .internalServerError
         case .ivalidHeaderFormat: return .badRequest
         }

--- a/Sources/NMeta/Version.swift
+++ b/Sources/NMeta/Version.swift
@@ -4,19 +4,19 @@ public struct Version {
     public let patch: Int
 
     public var string: String {
-        return "\(major).\(minor).\(patch)"
+        "\(major).\(minor).\(patch)"
     }
 
     public init(string: String) throws {
         let components = string.components(separatedBy: ".")
-        var numbers    = components.compactMap({ Int($0) })
+        var numbers = components.compactMap(Int.init)
 
         guard !numbers.isEmpty else {
             throw NMetaError.versionIsIncorrectFormat
         }
 
         major = numbers.removeFirst()
-        minor = !numbers.isEmpty ? numbers.removeFirst() : 0
-        patch = !numbers.isEmpty ? numbers.removeFirst() : 0
+        minor = numbers.isEmpty ? 0 : numbers.removeFirst()
+        patch = numbers.isEmpty ? 0 : numbers.removeFirst()
     }
 }


### PR DESCRIPTION
- deviceOs -> deviceOS
- add check for number of components to prevent crash
- reuse init logic from Request.NMeta
- remove headerIsEmpty error. Combined with invalidHeaderFormat
- added "NMeta: " prefix to error messages.