### PR TITLE
Improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 This package enforces clients to send a specific header in all requests:
 
 ```
-NMeta: [PLATFORM];[ENVIRONMENT];[APP_VERSION];[DEVICE_OS];[DEVICE]
+N-Meta: [PLATFORM];[ENVIRONMENT];[APP_VERSION];[DEVICE_OS];[DEVICE]
 ```
 
 If you're running an older version of Vapor then have a look here:

--- a/Sources/NMeta/Extensions/Application+NMeta.swift
+++ b/Sources/NMeta/Extensions/Application+NMeta.swift
@@ -7,16 +7,16 @@ public extension Application {
         public var headerName: String
 
         /// Supported platforms
-        public var platforms: [String]
+        public var platforms: Set<String>
 
         /// Supported environments
-        public var environments: [String]
+        public var environments: Set<String>
 
         /// Ignore requirement on following paths
         public var exceptPaths: [String]
 
         /// Only check header on following environments
-        public var requiredEnvironments: [String]
+        public var requiredEnvironments: Set<String>
 
         /// Create a new `NMeta` configuration value.
         /// - Parameters:
@@ -28,10 +28,10 @@ public extension Application {
         ///   - requiredEnvironments: environments to check NMeta header for
         public init(
             headerName: String = "N-Meta",
-            platforms: [String] = ["web", "android", "ios"],
-            environments: [String] = ["local", "development", "staging", "production"],
+            platforms: Set<String> = ["web", "android", "ios"],
+            environments: Set<String> = ["local", "development", "staging", "production"],
             exceptPaths: [String] = ["/js/*", "/css/*", "/images/*", "/favicons/*", "/admin/*"],
-            requiredEnvironments: [String] = ["local", "development", "staging", "production"]
+            requiredEnvironments: Set<String> = ["local", "development", "staging", "production"]
         ) {
             self.headerName = headerName
             self.platforms = platforms

--- a/Tests/NMetaTests/NMetaTests.swift
+++ b/Tests/NMetaTests/NMetaTests.swift
@@ -6,10 +6,10 @@ class NMetaTests: XCTestCase {
     var nMeta: Request.NMeta?
 
     let headerName = "N-Meta"
-    let platforms = ["web", "android", "ios"]
-    let environments = ["testing"]
+    let platforms: Set<String> = ["web", "android", "ios"]
+    let environments: Set<String> = ["testing"]
     let exceptPaths = ["/js/*", "/css/*", "/images/*", "/favicons/*", "/admin/*"]
-    let requiredEnvironments = ["testing"]
+    let requiredEnvironments: Set<String> = ["testing"]
 
     override func setUp() {
         app = Application(.testing)


### PR DESCRIPTION
Changes types of `platforms`, `environments`, and `requiredEnvironments` in `Application.NMeta` from `[String]` to `Set<String>` to speed up the header check. This is a breaking change but should not cause problems and we're still haven't reached 4.0.0 yet.